### PR TITLE
Full code review: freedv bump, WSJT-X zap bundle ids, cockpit macOS mins, xastir test, livecheck CI

### DIFF
--- a/.github/workflows/livecheck.yml
+++ b/.github/workflows/livecheck.yml
@@ -35,9 +35,23 @@ jobs:
         run: |
           echo "Running livecheck..."
 
-          # Run livecheck, keeping stdout (updates) separate from stderr (errors)
-          # Pipe through sed to strip ANSI color codes so downstream parsing works
-          LIVECHECK_OUTPUT=$(brew livecheck --tap gm5dna/amateur-radio --newer-only 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g') || true
+          # Run livecheck, capturing stdout and stderr to files so a total
+          # failure (network outage, broken tap) is surfaced instead of being
+          # silently treated as "no updates". Capture the exit code directly
+          # (no pipe) so it reflects brew livecheck rather than a downstream
+          # filter, and so it cannot interact with the shell's pipefail option.
+          LIVECHECK_RC=0
+          brew livecheck --tap gm5dna/amateur-radio --newer-only >livecheck.out 2>livecheck.err || LIVECHECK_RC=$?
+
+          # Strip ANSI colour codes so downstream parsing works.
+          LIVECHECK_OUTPUT=$(sed 's/\x1b\[[0-9;]*m//g' livecheck.out)
+
+          # A non-zero exit with no parsed output means livecheck itself failed
+          # (as opposed to individual flaky casks while others succeeded).
+          if [ "$LIVECHECK_RC" -ne 0 ] && [ -z "$LIVECHECK_OUTPUT" ]; then
+            echo "::warning::brew livecheck exited ${LIVECHECK_RC} with no output; treating as a failed run:"
+            cat livecheck.err
+          fi
 
           echo "Livecheck output:"
           echo "$LIVECHECK_OUTPUT"
@@ -50,7 +64,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           # Check if any lines contain "==>" indicating an actual version update
-          if echo "$LIVECHECK_OUTPUT" | grep -q "==>"; then
+          if grep -q "==>" <<<"$LIVECHECK_OUTPUT"; then
             echo "has_updates=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_updates=false" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ CONTRIBUTING.md
 claude.md
 claude-project.md
 docs/superpowers/
+REVIEW.md

--- a/Casks/freedv.rb
+++ b/Casks/freedv.rb
@@ -1,6 +1,6 @@
 cask "freedv" do
-  version "2.3.0"
-  sha256 "ed714f9ce4925c3bf9a0999a5ae01e48c3804e4d4c15e518d7b818ede5db7d45"
+  version "2.3.1"
+  sha256 "e95b39eb17793cff98d2e5709bb08871396775775ca816628d2d55763b9a0e50"
 
   url "https://github.com/drowe67/freedv-gui/releases/download/v#{version}/FreeDV-#{version}.dmg",
       verified: "github.com/drowe67/freedv-gui/"

--- a/Casks/ft710-cockpit.rb
+++ b/Casks/ft710-cockpit.rb
@@ -13,7 +13,7 @@ cask "ft710-cockpit" do
     strategy :page_match
   end
 
-  depends_on macos: :ventura
+  depends_on macos: :monterey
   depends_on cask: "silicon-labs-vcp-driver"
 
   app "FT-710 Cockpit.app"

--- a/Casks/ftdx10-cockpit.rb
+++ b/Casks/ftdx10-cockpit.rb
@@ -13,7 +13,7 @@ cask "ftdx10-cockpit" do
     strategy :page_match
   end
 
-  depends_on macos: :big_sur
+  depends_on macos: :monterey
   depends_on cask: "silicon-labs-vcp-driver"
 
   app "FTDX10 Cockpit.app"

--- a/Casks/wsjtx-improved-alt.rb
+++ b/Casks/wsjtx-improved-alt.rb
@@ -17,6 +17,9 @@ cask "wsjtx-improved-alt" do
   homepage "https://sourceforge.net/projects/wsjt-x-improved/"
 
   livecheck do
+    # Path is scoped to the current version directory (and macOS subdir) so the
+    # RSS feed reliably contains the macOS artefacts. Bump the path when upstream
+    # publishes a new WSJT-X_v<major> directory.
     url "https://sourceforge.net/projects/wsjt-x-improved/rss?path=/WSJT-X_v3.1.0/macOS"
     regex(%r{/wsjtx[._-]v?(\d+(?:\.\d+)+)[._-]improved[._-]AL[._-]PLUS[._-](\d+(?:-\w+)?)[._-]ARM}i)
     strategy :page_match do |page, regex|
@@ -30,8 +33,8 @@ cask "wsjtx-improved-alt" do
 
   zap trash: [
     "~/Library/Application Support/WSJT-X",
-    "~/Library/Preferences/wsjtx.plist",
-    "~/Library/Saved Application State/wsjtx.savedState",
+    "~/Library/Preferences/F6VY59P28F.org.ko3f.wsjtx.plist",
+    "~/Library/Saved Application State/F6VY59P28F.org.ko3f.wsjtx.savedState",
   ]
 
   caveats <<~EOS

--- a/Casks/wsjtx-improved-ws.rb
+++ b/Casks/wsjtx-improved-ws.rb
@@ -22,6 +22,9 @@ cask "wsjtx-improved-ws" do
   homepage "https://sourceforge.net/projects/wsjt-x-improved/"
 
   livecheck do
+    # Path is scoped to the current version directory (and macOS subdir) so the
+    # RSS feed reliably contains the macOS artefacts. Bump the path when upstream
+    # publishes a new WSJT-X_v<major> directory.
     url "https://sourceforge.net/projects/wsjt-x-improved/rss?path=/WSJT-X_v3.1.0/macOS"
     regex(%r{/wsjtx[._-]v?(\d+(?:\.\d+)+)[._-]improved[._-]widescreen[._-]PLUS[._-](\d+(?:-\w+)?)[._-]ARM}i)
     strategy :page_match do |page, regex|
@@ -35,8 +38,8 @@ cask "wsjtx-improved-ws" do
 
   zap trash: [
     "~/Library/Application Support/WSJT-X",
-    "~/Library/Preferences/wsjtx.plist",
-    "~/Library/Saved Application State/wsjtx.savedState",
+    "~/Library/Preferences/F6VY59P28F.org.ko3f.wsjtx.plist",
+    "~/Library/Saved Application State/F6VY59P28F.org.ko3f.wsjtx.savedState",
   ]
 
   caveats <<~EOS

--- a/Casks/wsjtx-improved.rb
+++ b/Casks/wsjtx-improved.rb
@@ -17,6 +17,9 @@ cask "wsjtx-improved" do
   homepage "https://sourceforge.net/projects/wsjt-x-improved/"
 
   livecheck do
+    # Path is scoped to the current version directory (and macOS subdir) so the
+    # RSS feed reliably contains the macOS artefacts. Bump the path when upstream
+    # publishes a new WSJT-X_v<major> directory.
     url "https://sourceforge.net/projects/wsjt-x-improved/rss?path=/WSJT-X_v3.1.0/macOS"
     regex(%r{/wsjtx[._-]v?(\d+(?:\.\d+)+)[._-]improved[._-]PLUS[._-](\d+(?:-\w+)?)[._-]ARM}i)
     strategy :page_match do |page, regex|
@@ -30,8 +33,8 @@ cask "wsjtx-improved" do
 
   zap trash: [
     "~/Library/Application Support/WSJT-X",
-    "~/Library/Preferences/wsjtx.plist",
-    "~/Library/Saved Application State/wsjtx.savedState",
+    "~/Library/Preferences/F6VY59P28F.org.ko3f.wsjtx.plist",
+    "~/Library/Saved Application State/F6VY59P28F.org.ko3f.wsjtx.savedState",
   ]
 
   caveats <<~EOS

--- a/Casks/wsjtx.rb
+++ b/Casks/wsjtx.rb
@@ -33,8 +33,8 @@ cask "wsjtx" do
 
   zap trash: [
     "~/Library/Application Support/WSJT-X",
-    "~/Library/Preferences/org.wsjtx.WSJTX.plist",
-    "~/Library/Saved Application State/org.wsjtx.WSJTX.savedState",
+    "~/Library/Preferences/org.k1jt.wsjtx.plist",
+    "~/Library/Saved Application State/org.k1jt.wsjtx.savedState",
   ]
 
   caveats <<~EOS

--- a/Formula/xastir.rb
+++ b/Formula/xastir.rb
@@ -60,6 +60,6 @@ class Xastir < Formula
 
   test do
     assert_predicate bin/"xastir", :executable?
-    assert_match version.to_s, shell_output("#{bin}/xastir -V 2>&1", 1)
+    assert_match version.to_s, shell_output("#{bin}/xastir -V 2>&1")
   end
 end

--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ Homebrew chooses formula or cask automatically when the name is unambiguous. If 
 brew install gm5dna/amateur-radio/wsjtx
 ```
 
-A few formulae are marked **`--HEAD` only** in the table below — these track upstream's main branch because there's no stable release tagged yet. Install them with:
-
-```bash
-brew install --HEAD <name>
-```
-
 ## Available Software
 
 ### Formulae
@@ -53,7 +47,7 @@ brew install --HEAD <name>
 | [**nanovnasaver**](https://github.com/NanoVNA-Saver/nanovna-saver) | Tool for reading, displaying, and saving data from NanoVNA analysers |
 | [**pat**](https://github.com/la5nta/pat) | Winlink client for emergency communications |
 | [**qttermtcp**](https://github.com/g8bpq/QtTermTCP) | Terminal emulator for packet radio communication by John Wiseman G8BPQ |
-| [**samoyed**](https://github.com/doismellburning/samoyed) | Software modem/TNC for packet radio (Go port of Dire Wolf) — `--HEAD` only |
+| [**samoyed**](https://github.com/doismellburning/samoyed) | Software modem/TNC for packet radio (Go port of Dire Wolf) |
 | [**voacapl**](https://github.com/jawatson/voacapl) | HF propagation prediction engine (port of VOACAP) |
 | [**wsjtz**](https://github.com/sq9fve/wsjt-z) | Weak-signal digital communication with automation features |
 | [**xastir**](https://github.com/Xastir/Xastir) | APRS client with mapping and weather alert support |


### PR DESCRIPTION
Full code review of the tap with Claude as primary reviewer and Codex as an independent **adversarial** second reviewer (read-only) at three checkpoints: a baseline whole-repo teardown, per-dimension refutation, and a final pass attempting to break the diff.

## Context
Baseline `brew style` and `brew audit --strict` were already **clean** across all 33 casks + 9 formulae, and livecheck flagged a single outdated package. The findings below are verified correctness/freshness issues, not widespread defects.

## Fixed (each verified)
- **freedv** 2.3.0 → 2.3.1 (livecheck; sha256 confirmed via `brew fetch`).
- **wsjtx** zap: `org.wsjtx.WSJTX.*` → `org.k1jt.wsjtx.*`. The real `CFBundleIdentifier` (read from the expanded `.pkg` payload) is `org.k1jt.wsjtx` — matching the cask's own `uninstall` stanza — so the old saved-state entry never matched.
- **wsjtx-improved{,-alt,-ws}** zap: `wsjtx.*` → `F6VY59P28F.org.ko3f.wsjtx.*` (bundle id verified from all three `.app` bundles).
- **ft710-cockpit** `:ventura` → `:monterey`; **ftdx10-cockpit** `:big_sur` → `:monterey` (both match upstream's stated macOS minimum; aligns the sibling apps).
- **Formula/xastir** test: `xastir -V` exits 0, not 1 — removed the wrong expected exit code (latent bug; CI audits but never `brew test`s).
- **.github/workflows/livecheck.yml**: a total livecheck failure no longer reads as "no updates" (exit code captured without a pipe; here-string match avoids a `pipefail` SIGPIPE false-negative on `grep -q`'s early exit).
- **README**: removed the obsolete `--HEAD`-only note on samoyed (it has a stable tag).

## Verification
- `brew style` clean on all 42 files; `brew audit --strict` clean on all changed casks/formulae.
- All **9 formulae** build from source (`brew install --build-from-source`) and pass `brew test`.
- All changed casks' livechecks resolve correctly.

## Investigated & deliberately not changed
- `wsjtx-improved-ws` Intel `26052`: verified live the typo'd URL is HTTP 200 and the interpolated one 404s — the documented workaround is still required.
- `qttinysa` `sha256 arm:/intel:`, `qtsoundmodem` zap/caveats slash, `sdrplusplus*` `version :latest`, `js8call-improved` livecheck: all confirmed correct (Claude and Codex agreed).
- Recommendations left for maintainer judgement: full `audit-all` on PRs (CI cost), GitHub Action SHA-pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)