### PR TITLE
Fix deskhpsdr checksum and dead fldigi homepages; verify cask checksums on both architectures in CI

### DIFF
--- a/.github/scripts/dump-cask-artifacts.rb
+++ b/.github/scripts/dump-cask-artifacts.rb
@@ -1,0 +1,35 @@
+# Emit one TSV row per cask per architecture: token, arch, url, sha256.
+#
+# `brew info --json=v2 --cask` only ever describes the running architecture, so
+# an `on_intel` url/sha is invisible on an Apple Silicon machine. Loading each
+# cask under a simulated arch is the only way to see both, and it resolves
+# `#{version}` / `version.major_minor` interpolation for us.
+#
+# Run with: brew ruby .github/scripts/dump-cask-artifacts.rb
+
+require "cask/cask_loader"
+
+casks = Dir.glob(File.join(Dir.pwd, "Casks", "*.rb")).sort
+abort "no casks found under #{Dir.pwd}/Casks" if casks.empty?
+
+failed = false
+
+casks.each do |path|
+  token = File.basename(path, ".rb")
+
+  [:arm, :intel].each do |arch|
+    begin
+      Homebrew::SimulateSystem.with(arch: arch) do
+        cask = Cask::CaskLoader::FromPathLoader.new(path).load(config: nil)
+        puts [token, arch, cask.url.to_s, cask.sha256.to_s].join("\t")
+      end
+    rescue => e
+      # A cask that will not load is a hard failure: staying silent here would
+      # let an unverifiable cask masquerade as a verified one.
+      warn "ERROR loading #{token} (#{arch}): #{e.class}: #{e.message}"
+      failed = true
+    end
+  end
+end
+
+exit 1 if failed

--- a/.github/scripts/verify-cask-checksums.sh
+++ b/.github/scripts/verify-cask-checksums.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# Verify every cask's sha256 against GitHub's recorded release-asset digest,
+# for BOTH architectures, without downloading a byte.
+#
+# Why this exists: `brew fetch --cask` only downloads the artifact for the
+# architecture it is running on. On an Apple Silicon machine (and on the
+# arm64 CI runners) an `on_intel` sha256 is never validated, so a wrong one
+# passes every local check. That is exactly how a bogus Intel sha256 for
+# `sdr-angel` reached main. GitHub publishes `sha256:...` in each release
+# asset's `digest` field, which lets us check both arches from any host.
+#
+# It also catches upstream silently replacing an asset in place under an
+# unchanged tag (dl1bz/deskhpsdr did this to 2.7.19), which livecheck cannot
+# see because the version never changes.
+#
+# Exit 1 on any mismatch. Assets we cannot verify this way are reported
+# explicitly rather than passed over in silence.
+#
+# Pass --full (or VERIFY_FULL=1) to additionally download and hash every
+# artifact that has a sha256 but is not a digest-bearing GitHub release asset
+# (SourceForge, S3, plain web hosts). That closes the gap for their Intel
+# builds too, at the cost of a couple of GB, so CI runs it on the daily
+# schedule rather than on every push.
+#
+# Requires: brew (with this tap available), gh (authenticated via GH_TOKEN).
+# Written for bash 3.2 (macOS /bin/bash): no associative arrays.
+
+set -uo pipefail
+
+full=0
+case "${1:-}" in
+  --full) full=1 ;;
+  "") [ "${VERIFY_FULL:-0}" = "1" ] && full=1 ;;
+  *) echo "usage: $(basename "$0") [--full]" >&2; exit 2 ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root" || exit 1
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+rows="$work/rows.tsv"
+cache="$work/cache"
+mkdir -p "$cache"
+
+if ! brew ruby .github/scripts/dump-cask-artifacts.rb > "$rows"; then
+  echo "::error::failed to load one or more casks; see errors above"
+  exit 1
+fi
+[ -s "$rows" ] || { echo "::error::cask dump produced no rows"; exit 1; }
+
+# Collapse rows resolving to the same artifact (universal binaries, and
+# arm64-only casks whose simulated-intel row is identical).
+dedup="$work/dedup.tsv"
+awk -F'\t' '!seen[$3 "|" $4]++' "$rows" > "$dedup"
+
+# GitHub release-asset URL: /<owner>/<repo>/releases/download/<tag>/<asset>
+gh_asset_re='^https://github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(.+)$'
+
+mismatches=0 verified=0
+skipped_no_check=0 skipped_not_gh=0 skipped_no_digest=0
+skip_log="" mismatch_log=""
+
+while IFS=$'\t' read -r token arch url sha; do
+  [ -n "${url:-}" ] || continue
+
+  if [ "$sha" = "no_check" ]; then
+    skipped_no_check=$((skipped_no_check + 1))
+    skip_log+="  no_check    ${token} (${arch})  ${url}"$'\n'
+    continue
+  fi
+
+  if [[ ! "$url" =~ $gh_asset_re ]]; then
+    skipped_not_gh=$((skipped_not_gh + 1))
+    skip_log+="  not-github  ${token} (${arch})  ${url}"$'\n'
+    printf '%s\t%s\t%s\t%s\n' "$token" "$arch" "$url" "$sha" >> "$work/todo.tsv"
+    continue
+  fi
+
+  owner="${BASH_REMATCH[1]}"; repo="${BASH_REMATCH[2]}"
+  tag="${BASH_REMATCH[3]}";   asset="${BASH_REMATCH[4]}"
+
+  cache_file="$cache/$(printf '%s' "${owner}/${repo}@${tag}" | shasum -a 256 | cut -d' ' -f1)"
+  if [ ! -f "$cache_file" ]; then
+    if ! gh api "repos/${owner}/${repo}/releases/tags/${tag}" \
+           --jq '.assets[] | "\(.name)\t\(.digest)"' > "$cache_file" 2>/dev/null; then
+      echo "::error file=Casks/${token}.rb::${token} (${arch}): cannot read release ${owner}/${repo}@${tag}"
+      mismatch_log+="  UNREADABLE RELEASE  ${token} (${arch})  ${owner}/${repo}@${tag}"$'\n'
+      mismatches=$((mismatches + 1))
+      rm -f "$cache_file"
+      continue
+    fi
+  fi
+
+  digest="$(awk -F'\t' -v a="$asset" '$1 == a { print $2; exit }' "$cache_file")"
+
+  if [ -z "$digest" ]; then
+    echo "::error file=Casks/${token}.rb::${token} (${arch}): asset '${asset}' not found in release ${owner}/${repo}@${tag}"
+    mismatch_log+="  MISSING ASSET  ${token} (${arch})  ${asset}"$'\n'
+    mismatches=$((mismatches + 1))
+    continue
+  fi
+
+  if [ "$digest" = "null" ]; then
+    # Assets uploaded before GitHub recorded digests have none. Not a failure,
+    # but say so out loud rather than let a skip look like a pass.
+    skipped_no_digest=$((skipped_no_digest + 1))
+    skip_log+="  no-digest   ${token} (${arch})  ${asset}"$'\n'
+    printf '%s\t%s\t%s\t%s\n' "$token" "$arch" "$url" "$sha" >> "$work/todo.tsv"
+    continue
+  fi
+
+  actual="${digest#sha256:}"
+  if [ "$actual" = "$sha" ]; then
+    verified=$((verified + 1))
+  else
+    echo "::error file=Casks/${token}.rb::sha256 mismatch for ${token} (${arch}): declared ${sha}, upstream ${actual}"
+    mismatch_log+="  MISMATCH    ${token} (${arch}) ${asset}"$'\n'
+    mismatch_log+="              declared ${sha}"$'\n'
+    mismatch_log+="              upstream ${actual}"$'\n'
+    mismatches=$((mismatches + 1))
+  fi
+done < "$dedup"
+
+echo
+echo "Verified against GitHub release digests: ${verified}"
+echo "Not verifiable this way:"
+echo "  sha256 :no_check         ${skipped_no_check}"
+echo "  not a GitHub release     ${skipped_not_gh}"
+echo "  asset has no digest      ${skipped_no_digest}"
+
+downloaded=0
+if [ "$full" = "1" ] && [ -s "$work/todo.tsv" ]; then
+  echo
+  echo "--full: downloading and hashing $(wc -l < "$work/todo.tsv" | tr -d ' ') remaining artifact(s)"
+  echo
+
+  while IFS=$'\t' read -r token arch url sha; do
+    blob="$work/blob"
+    # --fail rejects non-2xx; curl exits 18 on a truncated body even when the
+    # server returned 200, which is how a partial SourceForge/CDN response
+    # otherwise masquerades as a checksum mismatch. Retry, then believe it.
+    if ! curl --fail --location --silent --show-error \
+              --retry 3 --retry-delay 2 --retry-all-errors \
+              --max-time 900 --output "$blob" "$url" 2>"$work/curl.err"; then
+      rc=$?
+      echo "::error file=Casks/${token}.rb::${token} (${arch}): download failed (curl exit ${rc}): $(tr -d '\n' < "$work/curl.err")"
+      mismatch_log+="  DOWNLOAD FAILED  ${token} (${arch})  curl exit ${rc}"$'\n'
+      mismatches=$((mismatches + 1))
+      rm -f "$blob"
+      continue
+    fi
+
+    actual="$(shasum -a 256 "$blob" | cut -d' ' -f1)"
+    bytes="$(wc -c < "$blob" | tr -d ' ')"
+    rm -f "$blob"
+
+    if [ "$actual" = "$sha" ]; then
+      downloaded=$((downloaded + 1))
+      printf '  ok        %-22s %-6s %10s bytes\n' "$token" "$arch" "$bytes"
+    else
+      echo "::error file=Casks/${token}.rb::sha256 mismatch for ${token} (${arch}): declared ${sha}, downloaded ${actual}"
+      mismatch_log+="  MISMATCH    ${token} (${arch}) ${url}"$'\n'
+      mismatch_log+="              declared   ${sha}"$'\n'
+      mismatch_log+="              downloaded ${actual} (${bytes} bytes)"$'\n'
+      mismatches=$((mismatches + 1))
+    fi
+  done < "$work/todo.tsv"
+
+  echo
+  echo "Verified by download: ${downloaded}"
+elif [ -n "$skip_log" ]; then
+  echo
+  echo "Unverified detail (these are NOT checked by this job; use --full):"
+  printf '%s' "$skip_log"
+fi
+
+# :no_check casks are unverifiable by construction, in every mode.
+if [ "$full" = "1" ] && [ "$skipped_no_check" -gt 0 ]; then
+  echo
+  echo "Still unverifiable (sha256 :no_check, ${skipped_no_check}): unversioned or"
+  echo "in-place-updated URLs where a checksum cannot be pinned."
+fi
+
+if [ "$mismatches" -gt 0 ]; then
+  echo
+  echo "FAILED: ${mismatches} checksum problem(s)"
+  printf '%s' "$mismatch_log"
+  exit 1
+fi
+
+echo
+echo "OK: no checksum mismatches"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,14 @@ on:
       - 'Casks/**'
       - 'Formula/**'
       - '.github/workflows/**'
+      - '.github/scripts/**'
   pull_request:
     branches: [main]
     paths:
       - 'Casks/**'
       - 'Formula/**'
       - '.github/workflows/**'
+      - '.github/scripts/**'
   # Daily canary so new Homebrew style/audit enforcements are caught on a
   # schedule rather than ambushing the next unrelated push.
   schedule:
@@ -61,3 +63,23 @@ jobs:
             echo "Auditing: $formula_name"
             brew audit --formula "$formula_name"
           done
+
+      # The runners are arm64, and `brew fetch` only downloads the current
+      # architecture's artifact, so an `on_intel` sha256 is never exercised by
+      # the steps above. Compare both arches against GitHub's release-asset
+      # digests instead: no downloads, and it also catches upstream replacing
+      # an asset in place under an unchanged tag.
+      - name: Verify cask checksums against GitHub release digests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/verify-cask-checksums.sh
+
+      # Casks hosted off GitHub (SourceForge, S3, plain web hosts) have no
+      # published digest, so the only way to check their Intel builds is to
+      # download and hash. That is a couple of GB, so it runs on the daily
+      # schedule rather than on every push.
+      - name: Verify remaining cask checksums by download
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/verify-cask-checksums.sh --full

--- a/Casks/deskhpsdr.rb
+++ b/Casks/deskhpsdr.rb
@@ -1,6 +1,6 @@
 cask "deskhpsdr" do
   version "2.7.19"
-  sha256 "43d617ffa74f2bc00d2b5a28319848a2756586764171cb37165fdf0ec81b362f"
+  sha256 "dbad6e99be4530f2528b425db14bcafe7bac887fecac6457f86c80df03b7f2b3"
 
   url "https://github.com/dl1bz/deskhpsdr/releases/download/#{version}/deskHPSDR-v#{version.major_minor}-macos-arm64.zip"
   name "deskHPSDR"
@@ -20,8 +20,8 @@ cask "deskhpsdr" do
 
   zap trash: [
     "~/Library/Application Support/deskHPSDR",
-    "~/Library/Preferences/org.deskhpsdr.dl1bz.app.plist",
-    "~/Library/Saved Application State/org.deskhpsdr.dl1bz.app.savedState",
+    "~/Library/Preferences/org.dl1bz.deskhpsdr.plist",
+    "~/Library/Saved Application State/org.dl1bz.deskhpsdr.savedState",
   ]
 
   caveats <<~EOS

--- a/Casks/flaa.rb
+++ b/Casks/flaa.rb
@@ -2,11 +2,10 @@ cask "flaa" do
   version "1.0.2"
   sha256 "e8d7e610e6775d0e852c7876592dc2751adfafd00b8497a7cc1a643c551e6f88"
 
-  url "https://www.w1hkj.org/files/flaa/flaa-#{version}.dmg",
-      verified: "w1hkj.org/files/flaa/"
+  url "https://www.w1hkj.org/files/flaa/flaa-#{version}.dmg"
   name "flaa"
   desc "Antenna-analyser control for RigExpert AA-series instruments"
-  homepage "http://www.w1hkj.com/"
+  homepage "https://www.w1hkj.org/"
 
   livecheck do
     url "https://www.w1hkj.org/files/flaa/"

--- a/Casks/flamp.rb
+++ b/Casks/flamp.rb
@@ -2,11 +2,10 @@ cask "flamp" do
   version "2.2.14"
   sha256 "9e95cbd69b9741362d191880ec74c7b35c05fca19da345ce3f71fcc4a2f8d194"
 
-  url "https://www.w1hkj.org/files/flamp/flamp-#{version}_VN.dmg",
-      verified: "w1hkj.org/files/flamp/"
+  url "https://www.w1hkj.org/files/flamp/flamp-#{version}_VN.dmg"
   name "flamp"
   desc "Amateur Multicast Protocol file transfer for the fldigi suite"
-  homepage "http://www.w1hkj.com/"
+  homepage "https://www.w1hkj.org/"
 
   livecheck do
     url "https://www.w1hkj.org/files/flamp/"

--- a/Casks/flcluster.rb
+++ b/Casks/flcluster.rb
@@ -2,11 +2,10 @@ cask "flcluster" do
   version "1.1.01"
   sha256 "72acdeb07db3a6dc9cb3e5f8d8e6ef9d08026ca11c553dd7e960cee9613dc116"
 
-  url "https://www.w1hkj.org/files/flcluster/flcluster-#{version}.dmg",
-      verified: "w1hkj.org/files/flcluster/"
+  url "https://www.w1hkj.org/files/flcluster/flcluster-#{version}.dmg"
   name "flcluster"
   desc "DX telnet cluster client for the fldigi suite"
-  homepage "http://www.w1hkj.com/"
+  homepage "https://www.w1hkj.org/"
 
   livecheck do
     url "https://www.w1hkj.org/files/flcluster/"

--- a/Casks/fllog.rb
+++ b/Casks/fllog.rb
@@ -2,11 +2,10 @@ cask "fllog" do
   version "1.2.9"
   sha256 "48ed1041b2eba035fab56a57684aeadc1872c36faa2cd7830eb47348f61d692b"
 
-  url "https://www.w1hkj.org/files/fllog/fllog-#{version}.dmg",
-      verified: "w1hkj.org/files/fllog/"
+  url "https://www.w1hkj.org/files/fllog/fllog-#{version}.dmg"
   name "fllog"
   desc "Logbook server shared across the fldigi suite over XML-RPC"
-  homepage "http://www.w1hkj.com/"
+  homepage "https://www.w1hkj.org/"
 
   livecheck do
     url "https://www.w1hkj.org/files/fllog/"

--- a/Casks/flmsg.rb
+++ b/Casks/flmsg.rb
@@ -2,11 +2,10 @@ cask "flmsg" do
   version "4.0.24"
   sha256 "1f47338e2c18d27ef0c9f25ac60a61049a7797a0a751b2cf30c58a949e5ee4a8"
 
-  url "https://www.w1hkj.org/files/flmsg/flmsg-#{version}.dmg",
-      verified: "w1hkj.org/files/flmsg/"
+  url "https://www.w1hkj.org/files/flmsg/flmsg-#{version}.dmg"
   name "flmsg"
   desc "NBEMS structured-message and forms editor for the fldigi suite"
-  homepage "http://www.w1hkj.com/"
+  homepage "https://www.w1hkj.org/"
 
   livecheck do
     url "https://www.w1hkj.org/files/flmsg/"

--- a/Casks/flnet.rb
+++ b/Casks/flnet.rb
@@ -2,11 +2,10 @@ cask "flnet" do
   version "7.5.0"
   sha256 "08bac1646c97007bf49fac60a9ecb25ddc4b9601c3eaafa6557b519e77c02162"
 
-  url "https://www.w1hkj.org/files/flnet/flnet-#{version}_BS.dmg",
-      verified: "w1hkj.org/files/flnet/"
+  url "https://www.w1hkj.org/files/flnet/flnet-#{version}_BS.dmg"
   name "flnet"
   desc "Net-control roster and check-in logging for the fldigi suite"
-  homepage "http://www.w1hkj.com/"
+  homepage "https://www.w1hkj.org/"
 
   livecheck do
     url "https://www.w1hkj.org/files/flnet/"

--- a/Casks/flwkey.rb
+++ b/Casks/flwkey.rb
@@ -2,11 +2,10 @@ cask "flwkey" do
   version "1.2.4"
   sha256 "278138b3b9f942f579bea3726e2c644f075fd7ba1511e438cf99f296e8f7a01c"
 
-  url "https://www.w1hkj.org/files/flwkey/flwkey-#{version}.dmg",
-      verified: "w1hkj.org/files/flwkey/"
+  url "https://www.w1hkj.org/files/flwkey/flwkey-#{version}.dmg"
   name "flwkey"
   desc "Control app for K1EL Winkeyer CW keyers"
-  homepage "http://www.w1hkj.com/"
+  homepage "https://www.w1hkj.org/"
 
   livecheck do
     url "https://www.w1hkj.org/files/flwkey/"

--- a/Casks/flwrap.rb
+++ b/Casks/flwrap.rb
@@ -2,11 +2,10 @@ cask "flwrap" do
   version "1.3.6"
   sha256 "fedd5942860932676b527e6d4811d486b9c12657d6834e59833780fe4bc52dbf"
 
-  url "https://www.w1hkj.org/files/flwrap/flwrap-#{version}_BS.dmg",
-      verified: "w1hkj.org/files/flwrap/"
+  url "https://www.w1hkj.org/files/flwrap/flwrap-#{version}_BS.dmg"
   name "flwrap"
   desc "File encapsulation and checksums for radio file transfer"
-  homepage "http://www.w1hkj.com/"
+  homepage "https://www.w1hkj.org/"
 
   livecheck do
     url "https://www.w1hkj.org/files/flwrap/"

--- a/Casks/ft710-cockpit.rb
+++ b/Casks/ft710-cockpit.rb
@@ -13,7 +13,7 @@ cask "ft710-cockpit" do
     strategy :page_match
   end
 
-  depends_on macos: :monterey
+  depends_on macos: :ventura
   depends_on cask: "silicon-labs-vcp-driver"
 
   app "FT-710 Cockpit.app"

--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ names (e.g. `flmsg.app`) despite the version-stamped bundles upstream ships.
 
 | Name | Description |
 |------|-------------|
-| [**flmsg**](http://www.w1hkj.com/) | NBEMS structured-message and forms editor for the fldigi suite |
-| [**flamp**](http://www.w1hkj.com/) | Amateur Multicast Protocol file transfer for the fldigi suite |
-| [**flwkey**](http://www.w1hkj.com/) | Control app for K1EL Winkeyer CW keyers |
-| [**fllog**](http://www.w1hkj.com/) | Logbook server shared across the fldigi suite over XML-RPC |
-| [**flnet**](http://www.w1hkj.com/) | Net-control roster and check-in logging for the fldigi suite |
-| [**flcluster**](http://www.w1hkj.com/) | DX telnet cluster client for the fldigi suite |
-| [**flwrap**](http://www.w1hkj.com/) | File encapsulation and checksums for radio file transfer |
-| [**flaa**](http://www.w1hkj.com/) | Antenna-analyser control for RigExpert AA-series instruments (Intel; needs Rosetta on Apple Silicon) |
+| [**flmsg**](https://www.w1hkj.org/) | NBEMS structured-message and forms editor for the fldigi suite |
+| [**flamp**](https://www.w1hkj.org/) | Amateur Multicast Protocol file transfer for the fldigi suite |
+| [**flwkey**](https://www.w1hkj.org/) | Control app for K1EL Winkeyer CW keyers |
+| [**fllog**](https://www.w1hkj.org/) | Logbook server shared across the fldigi suite over XML-RPC |
+| [**flnet**](https://www.w1hkj.org/) | Net-control roster and check-in logging for the fldigi suite |
+| [**flcluster**](https://www.w1hkj.org/) | DX telnet cluster client for the fldigi suite |
+| [**flwrap**](https://www.w1hkj.org/) | File encapsulation and checksums for radio file transfer |
+| [**flaa**](https://www.w1hkj.org/) | Antenna-analyser control for RigExpert AA-series instruments (Intel; needs Rosetta on Apple Silicon) |
 
 #### Logging & QSL Management
 


### PR DESCRIPTION
## Summary

Started as a merge conflict in `Casks/sdr-angel.rb` (`brew` reported the cask as unreadable) and turned into a review of all 54 casks and 10 formulae. Every unique `(url, sha256)` pair was verified against upstream — 20 via GitHub release digests, 29 by downloading and hashing.

### Fixes

- **`deskhpsdr` was broken.** `brew install deskhpsdr` failed today: upstream replaced `deskHPSDR-v2.7-macos-arm64.zip` **in place** under the unchanged `2.7.19` tag (asset created `2026-07-09T08:56Z`, hours after the cask was bumped). The replacement is a genuine maintainer rebuild — signed `Developer ID Application: Heiko Amft (SAJWA8RU2X)`, full Apple chain, hardened runtime, `CFBundleShortVersionString 2.7.19`.
- **`deskhpsdr` zap never worked.** The cask carried a guessed, reversed `org.deskhpsdr.dl1bz.app`; the artifact's real `CFBundleIdentifier` is `org.dl1bz.deskhpsdr`. macOS writes prefs to `~/Library/Preferences/<CFBundleIdentifier>.plist`, so `--zap` left preferences behind.
- **Eight dead homepages.** All `fl*` casks pointed at `http://www.w1hkj.com/`, which is **NXDOMAIN** — not a redirect. The project site is `w1hkj.org`, already used for their downloads. With both domains now matching, `verified:` became redundant and `brew audit --strict` rejects it, so it is removed. README links updated too.
- **`ft710-cockpit` under-declared its minimum.** The artifact requires Ventura; the cask said Monterey, letting it install where the app will not run.

### New CI check

`brew fetch --cask` only downloads the artifact for the architecture it runs on. On Apple Silicon — and on the arm64 CI runners — an `on_intel` sha256 is **never validated**. That is how a bogus Intel sha256 for `sdr-angel` reached `main` under a commit message claiming "verified with brew fetch".

The existing `brew audit --cask` step runs offline and never downloads, so it cannot catch a bad checksum either. It passed this morning while `deskhpsdr` was broken.

`.github/scripts/verify-cask-checksums.sh` compares **both architectures** against GitHub's release-asset `digest` field, with no downloads. It also catches upstream replacing an asset in place under an unchanged tag, which livecheck is structurally blind to because the version never changes.

- fast mode (every push/PR): **20** casks via release digests
- `--full` (daily schedule): downloads and hashes the **29** artifacts hosted off GitHub, covering their Intel builds
- **22** casks remain unverifiable by construction (`sha256 :no_check`); every skip is printed with its reason rather than passed over in silence

## Test plan

- [x] `brew style gm5dna/amateur-radio` — 70 files, no offenses
- [x] `brew audit --strict --online` on all 10 changed casks
- [x] All 10 formulae pass `brew audit --strict --online` (note: `brew audit --tap` audits casks only)
- [x] `brew fetch --cask deskhpsdr` succeeds against a cleared cache
- [x] `brew livecheck --tap` — "No newer upstream versions"
- [x] All 53 remaining homepages return 200
- [x] Verifier red/green tested: correct sha → exit 0; corrupted sha → exit 1; unparseable cask → exit 1; both digest and download paths
- [x] Replayed the original bogus Intel sha for `sdr-angel`: caught as `sha256 mismatch for sdr-angel (intel)`
- [x] `--full` run over the whole tap: 20 + 29 verified, 0 mismatches
- [x] Script runs from a pristine clone; recorded mode `100755`

## Notes

- Written for bash 3.2 (macOS `/bin/bash` has no associative arrays).
- The download path checks `curl`'s **exit code**, not just HTTP status: a truncated body returns `200` *and* exit 18, which otherwise surfaces as a phantom checksum mismatch. Observed twice from SourceForge while preparing this.
- `--full` pulls ~1.3 GB on each daily run. One `if:` line moves it to weekly or manual-only.
- Left alone as intentional: `wsjtx-improved-ws`'s `26052` URL (upstream typo), `cocoamodem` `:sequoia` and `wfview` `:ventura` (upstream-stated minimums beating stale `Info.plist` values), `wfview-beta` tracking a pre-release, and the bare `depends_on :macos` in the `fl*` casks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)