### PR TITLE
Full review and CI resilience

### DIFF
--- a/.github/scripts/verify-cask-checksums.sh
+++ b/.github/scripts/verify-cask-checksums.sh
@@ -50,10 +50,12 @@ if ! brew ruby .github/scripts/dump-cask-artifacts.rb > "$rows"; then
 fi
 [ -s "$rows" ] || { echo "::error::cask dump produced no rows"; exit 1; }
 
-# Collapse rows resolving to the same artifact (universal binaries, and
-# arm64-only casks whose simulated-intel row is identical).
+# Collapse a cask's rows that resolve to the same artifact (universal
+# binaries, and arm64-only casks whose simulated-intel row is identical).
+# The token is part of the key so two casks sharing a URL are each checked
+# and each named in any error.
 dedup="$work/dedup.tsv"
-awk -F'\t' '!seen[$3 "|" $4]++' "$rows" > "$dedup"
+awk -F'\t' '!seen[$1 "|" $3 "|" $4]++' "$rows" > "$dedup"
 
 # GitHub release-asset URL: /<owner>/<repo>/releases/download/<tag>/<asset>
 gh_asset_re='^https://github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(.+)$'
@@ -83,9 +85,19 @@ while IFS=$'\t' read -r token arch url sha; do
 
   cache_file="$cache/$(printf '%s' "${owner}/${repo}@${tag}" | shasum -a 256 | cut -d' ' -f1)"
   if [ ! -f "$cache_file" ]; then
-    if ! gh api "repos/${owner}/${repo}/releases/tags/${tag}" \
-           --jq '.assets[] | "\(.name)\t\(.digest)"' > "$cache_file" 2>/dev/null; then
-      echo "::error file=Casks/${token}.rb::${token} (${arch}): cannot read release ${owner}/${repo}@${tag}"
+    # This runs on every push, so a momentary GitHub API error must not read
+    # as a broken release: try three times before believing it.
+    attempt=1
+    until gh api "repos/${owner}/${repo}/releases/tags/${tag}" \
+            --jq '.assets[] | "\(.name)\t\(.digest)"' > "$cache_file" 2>"$work/gh.err"; do
+      if [ "$attempt" -ge 3 ]; then
+        break
+      fi
+      attempt=$((attempt + 1))
+      sleep 5
+    done
+    if [ "$attempt" -ge 3 ] && ! [ -s "$cache_file" ]; then
+      echo "::error file=Casks/${token}.rb::${token} (${arch}): cannot read release ${owner}/${repo}@${tag}: $(tr -d '\n' < "$work/gh.err")"
       mismatch_log+="  UNREADABLE RELEASE  ${token} (${arch})  ${owner}/${repo}@${tag}"$'\n'
       mismatches=$((mismatches + 1))
       rm -f "$cache_file"
@@ -141,10 +153,11 @@ if [ "$full" = "1" ] && [ -s "$work/todo.tsv" ]; then
     # --fail rejects non-2xx; curl exits 18 on a truncated body even when the
     # server returned 200, which is how a partial SourceForge/CDN response
     # otherwise masquerades as a checksum mismatch. Retry, then believe it.
-    if ! curl --fail --location --silent --show-error \
-              --retry 3 --retry-delay 2 --retry-all-errors \
-              --max-time 900 --output "$blob" "$url" 2>"$work/curl.err"; then
-      rc=$?
+    curl --fail --location --silent --show-error \
+         --retry 3 --retry-delay 2 --retry-all-errors \
+         --max-time 900 --output "$blob" "$url" 2>"$work/curl.err"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
       echo "::error file=Casks/${token}.rb::${token} (${arch}): download failed (curl exit ${rc}): $(tr -d '\n' < "$work/curl.err")"
       mismatch_log+="  DOWNLOAD FAILED  ${token} (${arch})  curl exit ${rc}"$'\n'
       mismatches=$((mismatches + 1))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'Casks/**'
       - 'Formula/**'
+      - 'audit_exceptions/**'
       - '.github/workflows/**'
       - '.github/scripts/**'
   pull_request:
@@ -13,6 +14,7 @@ on:
     paths:
       - 'Casks/**'
       - 'Formula/**'
+      - 'audit_exceptions/**'
       - '.github/workflows/**'
       - '.github/scripts/**'
   # Daily canary so new Homebrew style/audit enforcements are caught on a
@@ -24,13 +26,17 @@ on:
 permissions:
   contents: read
 
+# Only pull request runs are superseded by a newer push. A run on main is
+# never cancelled: it is the record of whether main is green, and the notify
+# job below needs a complete result to act on.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  audit:
+  check:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -43,41 +49,21 @@ jobs:
           mkdir -p "$(brew --repository)/Library/Taps/gm5dna"
           ln -sfn "$(pwd)" "$(brew --repository)/Library/Taps/gm5dna/homebrew-amateur-radio"
 
-      # The tap is small enough that checking everything on every run is
-      # cheaper and safer than computing changed files from PR input.
+      # Every verification step below runs even when an earlier one fails, so
+      # a single run reports every problem rather than the first one hiding
+      # the rest. The tap is small enough that checking everything on every
+      # run is cheaper and safer than computing changed files from PR input.
       - name: Run brew style
         run: brew style gm5dna/amateur-radio
 
-      # Tokens are fully qualified because three of ours (picoscope,
-      # saleae-logic, sigdigger) also exist in homebrew/cask, and a bare
-      # token resolves to homebrew/cask's copy rather than this tap's.
-      # Every failure is collected so one run reports them all, rather than
-      # stopping at the first and masking the rest.
-      - name: Run brew audit on all casks
-        run: |
-          failed=""
-          for cask in Casks/*.rb; do
-            cask_name=$(basename "$cask" .rb)
-            echo "Auditing: $cask_name"
-            brew audit --cask "gm5dna/amateur-radio/$cask_name" || failed="$failed $cask_name"
-          done
-          if [ -n "$failed" ]; then
-            echo "::error::casks failed audit:$failed"
-            exit 1
-          fi
-
-      - name: Run brew audit on all formulae
-        run: |
-          failed=""
-          for formula in Formula/*.rb; do
-            formula_name=$(basename "$formula" .rb)
-            echo "Auditing: $formula_name"
-            brew audit --formula "gm5dna/amateur-radio/$formula_name" || failed="$failed $formula_name"
-          done
-          if [ -n "$failed" ]; then
-            echo "::error::formulae failed audit:$failed"
-            exit 1
-          fi
+      # `--tap` loads every formula and cask by file path, so the three
+      # tokens that also exist in homebrew/cask (picoscope, saleae-logic,
+      # sigdigger) are this tap's rather than homebrew/cask's, every failure
+      # is reported in one run, and Ruby boots once rather than once per
+      # package. It skips the style cops, which the step above covers.
+      - name: Run brew audit on the whole tap
+        if: ${{ !cancelled() }}
+        run: brew audit --tap gm5dna/amateur-radio
 
       # The runners are arm64, and `brew fetch` only downloads the current
       # architecture's artifact, so an `on_intel` sha256 is never exercised by
@@ -85,16 +71,114 @@ jobs:
       # digests instead: no downloads, and it also catches upstream replacing
       # an asset in place under an unchanged tag.
       - name: Verify cask checksums against GitHub release digests
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .github/scripts/verify-cask-checksums.sh
 
-      # Casks hosted off GitHub (SourceForge, S3, plain web hosts) have no
-      # published digest, so the only way to check their Intel builds is to
-      # download and hash. That is a couple of GB, so it runs on the daily
-      # schedule rather than on every push.
+  # Casks hosted off GitHub (SourceForge, S3, plain web hosts) have no
+  # published digest, so the only way to check their Intel builds is to
+  # download and hash. That is a couple of GB, so it runs on the daily
+  # schedule rather than on every push, and as its own job so that a
+  # third-party host being down shows up as this job failing rather than
+  # hiding a real style or audit regression in the same log.
+  download-verify:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+
+      - name: Tap this repository
+        run: |
+          mkdir -p "$(brew --repository)/Library/Taps/gm5dna"
+          ln -sfn "$(pwd)" "$(brew --repository)/Library/Taps/gm5dna/homebrew-amateur-radio"
+
       - name: Verify remaining cask checksums by download
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .github/scripts/verify-cask-checksums.sh --full
+
+  # Nobody watches the Actions tab, so a failing scheduled run used to sit
+  # unnoticed for days. A failure on main opens (or updates) one issue
+  # labelled `ci-failure`; the next green run closes it. Pull requests are
+  # excluded: their status is already visible on the PR.
+  notify:
+    needs: [check, download-verify]
+    if: always() && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or close the CI failure issue
+        uses: actions/github-script@v9
+        env:
+          CHECK_RESULT: ${{ needs.check.result }}
+          DOWNLOAD_RESULT: ${{ needs.download-verify.result }}
+        with:
+          script: |
+            const label = 'ci-failure';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const results = {
+              check: process.env.CHECK_RESULT,
+              'download-verify': process.env.DOWNLOAD_RESULT,
+            };
+            // A skipped job (download-verify on push) is not a failure.
+            const failed = Object.entries(results)
+              .filter(([, result]) => result === 'failure' || result === 'timed_out')
+              .map(([job]) => job);
+            const cancelled = Object.values(results).includes('cancelled');
+            if (cancelled) {
+              console.log('Run was cancelled; leaving any CI failure issue as it is.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: label,
+            });
+
+            if (failed.length === 0) {
+              for (const issue of open) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: issue.number,
+                  body: `CI is green again: ${runUrl}`,
+                });
+                await github.rest.issues.update({
+                  owner, repo, issue_number: issue.number, state: 'closed',
+                });
+                console.log(`Closed #${issue.number}`);
+              }
+              return;
+            }
+
+            const body = `Job(s) failed: **${failed.join('**, **')}** ` +
+              `(${context.eventName} on \`${context.ref}\`).\n\n${runUrl}`;
+            if (open.length > 0) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: open[0].number, body,
+              });
+              console.log(`Updated #${open[0].number}`);
+              return;
+            }
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner, repo, name: label, color: 'b60205',
+                description: 'Opened automatically when CI fails on main',
+              });
+            }
+            const issue = await github.rest.issues.create({
+              owner, repo, labels: [label],
+              title: 'CI is failing on main',
+              body: `${body}\n\nThis issue is closed automatically by the next green run.`,
+            });
+            console.log(`Opened #${issue.data.number}`);

--- a/.github/workflows/livecheck.yml
+++ b/.github/workflows/livecheck.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   livecheck:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -49,19 +50,36 @@ jobs:
 
           # A non-zero exit with no parsed output means livecheck itself failed
           # (as opposed to individual flaky casks while others succeeded).
+          LIVECHECK_FAILED=false
           if [ "$LIVECHECK_RC" -ne 0 ] && [ -z "$LIVECHECK_OUTPUT" ]; then
-            echo "::warning::brew livecheck exited ${LIVECHECK_RC} with no output; treating as a failed run:"
+            echo "::error::brew livecheck exited ${LIVECHECK_RC} with no output; treating as a failed run:"
             cat livecheck.err
+            LIVECHECK_FAILED=true
+          fi
+          echo "failed=${LIVECHECK_FAILED}" >> "$GITHUB_OUTPUT"
+
+          # Individual packages can fail (a host returning 403 to the runner
+          # IP, a timeout) while the run as a whole succeeds. Surface each one
+          # as a warning so a package that fails day after day is visible
+          # from the run list, instead of being buried in a log nobody opens.
+          # A single day's failure is usually a transient runner-IP block.
+          if [ -s livecheck.err ]; then
+            while IFS= read -r line; do
+              echo "::warning::livecheck: ${line}"
+            done < <(sed 's/\x1b\[[0-9;]*m//g' livecheck.err | grep -v '^[[:space:]]*$')
           fi
 
           echo "Livecheck output:"
           echo "$LIVECHECK_OUTPUT"
 
-          # Save output for next steps
+          # Save output for next steps. The delimiter is random so that a
+          # scraped line reading "EOF" cannot end the value early and smuggle
+          # further lines in as output commands.
+          delimiter="livecheck_$(uuidgen)"
           {
-            echo "output<<EOF"
+            echo "output<<${delimiter}"
             echo "$LIVECHECK_OUTPUT"
-            echo "EOF"
+            echo "${delimiter}"
           } >> "$GITHUB_OUTPUT"
 
           # Check if any lines contain "==>" indicating an actual version update
@@ -119,16 +137,20 @@ jobs:
             }
 
       - name: Summary
+        if: always()
         env:
           # env indirection, not ${{ }} interpolation into the script: the
           # livecheck output is untrusted third-party data.
           HAS_UPDATES: ${{ steps.livecheck.outputs.has_updates }}
+          LIVECHECK_FAILED: ${{ steps.livecheck.outputs.failed }}
           LIVECHECK_OUTPUT: ${{ steps.livecheck.outputs.output }}
         run: |
           {
             echo "## Livecheck Results"
             echo ""
-            if [ "$HAS_UPDATES" == "true" ]; then
+            if [ "$LIVECHECK_FAILED" == "true" ]; then
+              echo "brew livecheck failed outright; see the job log."
+            elif [ "$HAS_UPDATES" == "true" ]; then
               echo "### Updates Available"
               echo '```'
               echo "$LIVECHECK_OUTPUT"
@@ -137,3 +159,11 @@ jobs:
               echo "All packages are up to date."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # A run in which livecheck produced nothing is not "no updates". Fail
+      # it so it shows red in the run list, after the summary has been
+      # written; the issue-creation step above is already skipped because
+      # has_updates is false.
+      - name: Fail the run if livecheck itself failed
+        if: steps.livecheck.outputs.failed == 'true'
+        run: exit 1

--- a/Formula/mshv.rb
+++ b/Formula/mshv.rb
@@ -26,6 +26,15 @@ class Mshv < Formula
 
     # The build creates bin/MSHV.app
     prefix.install "bin/MSHV.app"
+
+    # The build creates these as empty, user-writable directories inside the
+    # bundle and Homebrew's cleaner removes empty directories from the keg,
+    # so leave a file in each to keep them.
+    resources = prefix/"MSHV.app/Contents/Resources"
+    %w[RxWavs log ExportLog AllTxtMonthly Screenshots].each do |dir|
+      (resources/dir).mkpath
+      touch resources/dir/".keep"
+    end
   end
 
   def post_install
@@ -52,10 +61,15 @@ class Mshv < Formula
       This is a native Apple Silicon port of LZ2HV's MSHV using PortAudio
       over CoreAudio. The bundle is not notarised.
 
-      User state (settings, logs, QSO history) lives in:
-        ~/Library/Application Support/MSHV/
-      so replacing the app preserves it. On first launch, macOS will ask
-      for microphone access for receive audio.
+      This port keeps user state (settings, macros, logs, QSO history)
+      inside the app bundle:
+        #{opt_prefix}/MSHV.app/Contents/Resources/
+      `brew upgrade` and `brew reinstall` replace the bundle, so copy the
+      settings/ and log/ directories somewhere safe first and copy them
+      back afterwards.
+
+      On first launch, macOS will ask for microphone access for receive
+      audio.
     EOS
   end
 

--- a/Formula/voacapl.rb
+++ b/Formula/voacapl.rb
@@ -28,6 +28,14 @@ class Voacapl < Formula
     system "make", "install"
   end
 
+  def caveats
+    <<~EOS
+      voacapl needs the itshfbc data directory in your home directory before
+      it can run. Create it once with:
+        makeitshfbc
+    EOS
+  end
+
   test do
     assert_path_exists bin/"voacapl"
   end

--- a/Formula/wsjtz.rb
+++ b/Formula/wsjtz.rb
@@ -65,7 +65,11 @@ class Wsjtz < Formula
     # official .pkg installer to load into /Library/LaunchDaemons
     # and has no effect from a Cellar path. Its presence also makes
     # `brew install` print a misleading `brew services start` hint.
-    rm(prefix/"com.wsjtx.sysctl.plist")
+    # Its companion ReadMe.txt describes that installer. Both are
+    # guarded so that upstream dropping either does not break the build.
+    %w[com.wsjtx.sysctl.plist ReadMe.txt].each do |file|
+      rm(prefix/file) if (prefix/file).exist?
+    end
   end
 
   def post_install


### PR DESCRIPTION
Full code review of the tap (Fable implementing; Opus, Sonnet and Codex reviewing) plus CI resilience work. Draft until the cask and formula findings are folded in.

## CI resilience (`ci.yml`, `livecheck.yml`, `verify-cask-checksums.sh`)

- Every check step runs even when an earlier one fails, so one run reports every problem.
- Formulae and casks are audited together with `brew audit --tap`, which loads files by path (so the three tokens shadowed by homebrew/cask are ours) and boots Ruby once instead of 74 times. Verified locally against a deliberately broken cask and formula; `--tap` skips style cops, which the separate `brew style` step covers.
- The daily `--full` download verification is its own job, so a third-party host outage fails visibly on its own.
- A `notify` job opens or updates one `ci-failure` issue when a run on main fails and closes it on the next green run.
- Runs on main are no longer cancelled by a newer push. Every job has a timeout. `audit_exceptions/**` now triggers CI.
- `livecheck.yml`: a run in which livecheck produced nothing now fails; per-package errors surface as warning annotations; the `GITHUB_OUTPUT` heredoc uses a random delimiter.
- `verify-cask-checksums.sh`: the masked curl exit code is fixed, the release lookup is retried, and casks sharing a URL are each checked.

## Verification

- `brew style`, `brew audit --tap`, `verify-cask-checksums.sh` all green locally on the branch.
- `actionlint` and `shellcheck` clean on both workflows and every embedded run block.
- This PR's own CI run exercises the new `check` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dkL4x5zvk1U1BJY7K99Ew
